### PR TITLE
Small fix for PlotFreeEnergies.py

### DIFF
--- a/v3.2beta/alf/util/PlotFreeEnergy.py
+++ b/v3.2beta/alf/util/PlotFreeEnergy.py
@@ -15,6 +15,7 @@ EmidX,EmidY=np.meshgrid(Emid2,Emid2)
 # nsubs=alf_info['nsubs']
 # nblocks=alf_info['nblocks']
 nsubs=np.loadtxt('../prep/nsubs',dtype='int')
+nsubs = np.atleast_1d(nsubs)
 nblocks=np.sum(nsubs)
 
 ntersite=[0,0]


### PR DESCRIPTION
nsubs = np.atleast_1d(nsubs) should be added

Reason:
 in case of 1 site, it may read the the nsubs file as 0-D array.