### PR TITLE
Deprecated method in GetLambda.py

### DIFF
--- a/v3.2beta/alf/GetLambda.py
+++ b/v3.2beta/alf/GetLambda.py
@@ -27,7 +27,7 @@ def GetLambdaCharmm(alf_info,fnmout,fnmsin):
     delta4 = (fp.read_record(dtype=np.float32))
 
     # Title in trajectoory file 
-    title = (fp.read_record([('h',np.int32,1),('title',np.string_,80)]))[0][1]
+    title = (fp.read_record(dtype=[('h', np.int32), ('title', 'S80')])['title'][0].decode()) 
 
     # Unused in current processing
     nbiasv = (fp.read_record(dtype=np.int32))


### PR DESCRIPTION
Small change in line 30 to avoid deprecated method.

FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.
  dtypes = tuple(np.dtype(dtype) for dtype in dtypes