### PR TITLE
Replace deprecated mpirun "--bynode" flag with "--map-by node"

### DIFF
--- a/alf/postprocessDCA.py
+++ b/alf/postprocessDCA.py
@@ -96,7 +96,7 @@ def FilterDCA(i,iNF,NF,FREQ,engine='charmm'):
   exe=os.path.dirname(os.path.abspath(__file__))+'/dca/Filter'
   fnmin=('../analysis%d/data/Lambda.%d.%d.dat' % (i,iNF,alf_info['ncentral']))
   fnmout=('data/Filter.%d.dat' % iNF)
-  subprocess.call(['mpirun','-n','1','-bynode','--bind-to','none','-x','OMP_NUM_THREADS=1',exe,str(FREQ),fnmin,fnmout])
+  subprocess.call(['mpirun','-n','1','--map-by','node','--bind-to','none','-x','OMP_NUM_THREADS=1',exe,str(FREQ),fnmin,fnmout])
   print("WARNING: direct standard error somewhere")
   time.sleep(15)
 
@@ -149,7 +149,7 @@ def MomentDCA(i,iNF,NF,FREQ,engine='charmm'):
   fnmin=('data/Filter.%d.dat' % iNF)
   fnmout1=('data/m1.%d.obs.dat' % iNF)
   fnmout2=('data/m2.%d.obs.dat' % iNF)
-  subprocess.call(['mpirun','-n','1','-bynode','--bind-to','none','-x','OMP_NUM_THREADS=1',exe,fnmin,fnmout1,fnmout2])
+  subprocess.call(['mpirun','-n','1','--map-by','node','--bind-to','none','-x','OMP_NUM_THREADS=1',exe,fnmin,fnmout1,fnmout2])
   print("WARNING: direct standard error somewhere")
   time.sleep(15)
 
@@ -252,7 +252,7 @@ def LMDCA(i,iBS,NF,FREQ,NBS=50,engine='charmm'):
     fnmout2=('data/J.bs%d.LM.dat' % iBS)
     fnmin1=('data/m1.bs%d.obs.dat' % iBS)
     fnmin2=('data/m2.bs%d.obs.dat' % iBS)
-  subprocess.call(['mpirun','-n','1','-bynode','--bind-to','none','-x','OMP_NUM_THREADS=8',exe,fnmout1,fnmout2,fnmin1,fnmin2])
+  subprocess.call(['mpirun','-n','1','--map-by','node','--bind-to','none','-x','OMP_NUM_THREADS=8',exe,fnmout1,fnmout2,fnmin1,fnmin2])
   time.sleep(15)
 
 def PLMDCA(i,iBS,NF,FREQ,NBS=50,engine='charmm'):
@@ -311,7 +311,7 @@ def PLMDCA(i,iBS,NF,FREQ,NBS=50,engine='charmm'):
   for bsindex in bsindices:
     fnmsin.append('data/Filter.%d.dat' % bsindex)
   print(fnmsin)
-  subprocess.call(['mpirun','-n','1','-bynode','--bind-to','none','-x','OMP_NUM_THREADS=1',exe,fnmout1,fnmout2]+fnmsin)
+  subprocess.call(['mpirun','-n','1','--map-by','node','--bind-to','none','-x','OMP_NUM_THREADS=1',exe,fnmout1,fnmout2]+fnmsin)
   time.sleep(15)
 
 def FinishDCA(i,NF,FREQ,NBS=50,engine='charmm'):

--- a/alf/runflat.py
+++ b/alf/runflat.py
@@ -109,14 +109,14 @@ def runflat(ni,nf,esteps,nsteps,engine='charmm',G_imp=None,ntersite=[0,0]):
         if not os.path.exists('../msld_flat.'+fex):
           print("Error: msld_flat.%s does not exist." % fex)
         if engine in ['charmm']:
-          subprocess.call(['mpirun','-np',str(alf_info['nreps']),'-x','OMP_NUM_THREADS=4','--bind-to','none','--bynode',alf_info['enginepath'],'esteps=%d' % esteps,'nsteps=%d' % nsteps,'seed=%d' % random.getrandbits(16),'-i','../msld_flat.inp'],stdout=fpout,stderr=fperr)
+          subprocess.call(['mpirun','-np',str(alf_info['nreps']),'-x','OMP_NUM_THREADS=4','--bind-to','none','--map-by','node',alf_info['enginepath'],'esteps=%d' % esteps,'nsteps=%d' % nsteps,'seed=%d' % random.getrandbits(16),'-i','../msld_flat.inp'],stdout=fpout,stderr=fperr)
         elif engine in ['bladelib']:
-          subprocess.call(['mpirun','-np',str(alf_info['nreps']),'-x','OMP_NUM_THREADS=1','--bind-to','none','--bynode',alf_info['enginepath'],'esteps=%d' % esteps,'nsteps=%d' % nsteps,'seed=%d' % random.getrandbits(16),'-i','../msld_flat.inp'],stdout=fpout,stderr=fperr)
+          subprocess.call(['mpirun','-np',str(alf_info['nreps']),'-x','OMP_NUM_THREADS=1','--bind-to','none','--map-by','node',alf_info['enginepath'],'esteps=%d' % esteps,'nsteps=%d' % nsteps,'seed=%d' % random.getrandbits(16),'-i','../msld_flat.inp'],stdout=fpout,stderr=fperr)
         elif engine in ['blade']:
           fpin=open('arguments.inp','w')
           fpin.write("variables set esteps %d\nvariables set nsteps %d" % (esteps,nsteps))
           fpin.close()
-          subprocess.call(['mpirun','-np',str(alf_info['nreps']),'-x','OMP_NUM_THREADS=1','--bind-to','none','--bynode',alf_info['enginepath'],'../msld_flat.inp'],stdout=fpout,stderr=fperr)
+          subprocess.call(['mpirun','-np',str(alf_info['nreps']),'-x','OMP_NUM_THREADS=1','--bind-to','none','--map-by','node',alf_info['enginepath'],'../msld_flat.inp'],stdout=fpout,stderr=fperr)
         elif engine in ['pycharmm']:
           fpin=open('arguments.py','w')
           fpin.write("esteps=%d\nnsteps=%d" % (esteps,nsteps))

--- a/alf/runprod.py
+++ b/alf/runprod.py
@@ -134,14 +134,14 @@ def runprod(step,a,itt0,itt,nsteps=500000,engine='charmm'):
         if not os.path.exists('../msld_prod.'+fex):
           print("Error: msld_prod.%s does not exist." % fex)
         if engine in ['charmm']:
-          subprocess.call(['mpirun','-np',str(alf_info['nreps']),'-x','OMP_NUM_THREADS=4','--bind-to','none','--bynode',alf_info['enginepath'],'nsteps=%d' % nsteps,'nsavc=10000','seed=%d' % random.getrandbits(16),'itt=%d' % i,'-i','../msld_prod.inp'],stdout=fpout,stderr=fperr)
+          subprocess.call(['mpirun','-np',str(alf_info['nreps']),'-x','OMP_NUM_THREADS=4','--bind-to','none','--map-by','node',alf_info['enginepath'],'nsteps=%d' % nsteps,'nsavc=10000','seed=%d' % random.getrandbits(16),'itt=%d' % i,'-i','../msld_prod.inp'],stdout=fpout,stderr=fperr)
         elif engine in ['bladelib']:
-          subprocess.call(['mpirun','-np',str(alf_info['nreps']),'-x','OMP_NUM_THREADS=1','--bind-to','none','--bynode',alf_info['enginepath'],'nsteps=%d' % nsteps,'nsavc=10000','seed=%d' % random.getrandbits(16),'itt=%d' % i,'-i','../msld_prod.inp'],stdout=fpout,stderr=fperr)
+          subprocess.call(['mpirun','-np',str(alf_info['nreps']),'-x','OMP_NUM_THREADS=1','--bind-to','none','--map-by','node',alf_info['enginepath'],'nsteps=%d' % nsteps,'nsavc=10000','seed=%d' % random.getrandbits(16),'itt=%d' % i,'-i','../msld_prod.inp'],stdout=fpout,stderr=fperr)
         elif engine in ['blade']:
           fpin=open('arguments.inp','w')
           fpin.write("variables set nsteps %d\nvariables set itt %d" % (nsteps,i))
           fpin.close()
-          subprocess.call(['mpirun','-np',str(alf_info['nreps']),'-x','OMP_NUM_THREADS=1','--bind-to','none','--bynode',alf_info['enginepath'],'../msld_prod.inp'],stdout=fpout,stderr=fperr)
+          subprocess.call(['mpirun','-np',str(alf_info['nreps']),'-x','OMP_NUM_THREADS=1','--bind-to','none','--map-by','node',alf_info['enginepath'],'../msld_prod.inp'],stdout=fpout,stderr=fperr)
         elif engine in ['pycharmm']:
           fpin=open('arguments.py','w')
           fpin.write("nsteps=%d\nitt=%d" % (nsteps,i))


### PR DESCRIPTION
Hey Ryan,

Running the latest ALF scripts with `mpirun` results in the following warning:

```
--------------------------------------------------------------------------
The following command line options and corresponding MCA parameter have
been deprecated and replaced as follows:

  Command line options:
    Deprecated:  --bynode, -bynode
    Replacement: --map-by node

  Equivalent MCA parameter:
    Deprecated:  rmaps_base_bynode
    Replacement: rmaps_base_mapping_policy=node

The deprecated forms *will* disappear in a future version of Open MPI.
Please update to the new syntax.
--------------------------------------------------------------------------
```

Seemed like a fairly straightforward change, so I modified the affected files to replace `--bynode` and `-bynode` with the replacement `--map-by node`.

Thanks,
Murphy
